### PR TITLE
Update thecodingmachine/safe to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^8",
         "matthiasmullie/minify": "^1.3",
-        "thecodingmachine/safe": "^1.0 || ^0.1 || ^2.2",
+        "thecodingmachine/safe": "^1.0 || ^0.1 || ^2.2 || ^3.0",
         "tubalmartin/cssmin": "^4.1",
         "websharks/css-minifier": "150820",
         "wyrihaximus/compress": "^1.1 || ^2.0",


### PR DESCRIPTION
thecodingmachine/safe issues deprecation warning on php8.4. Using the freshly released 3.0.0 fixes this issue.